### PR TITLE
Fix for seg fault in hostpathplugin

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -72,6 +72,9 @@ func (hp *hostPath) Run(driverName, nodeID, endpoint string) {
 
 	// Initialize default library driver
 	hp.driver = csicommon.NewCSIDriver(driverName, &version, GetSupportedVersions(), nodeID)
+        if hp.driver == nil {
+           glog.Fatalln("Failed to initialize CSI Driver.")
+        }
 	hp.driver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME})
 	hp.driver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER})
 


### PR DESCRIPTION
Fixing seg fault when hostpathplugon is called without any parameters

Closes# https://github.com/kubernetes-csi/drivers/issues/31