### PR TITLE
fix URL for drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 These drivers are provided purely for illustrative purposes, and should not be used for production workloads.
 
 ## Other sample drivers
-Please read [Drivers](https://github.com/kubernetes-csi/docs/wiki/Drivers) for more information
+Please read [Drivers](https://kubernetes-csi.github.io/docs/Drivers.html) for more information
 
 ## Adding new sample drivers
 Please, DO NOT submit PRs to add new drivers here unless they are just examples. Real CSI drivers are to be housed on their own repo separate from this one. You are then welcomed to send a PR to https://github.com/kubernetes-csi/docs to add the [Driver](https://github.com/kubernetes-csi/docs/wiki/Drivers) page.


### PR DESCRIPTION
The Wiki page was replaced by a book created from kubernetes-csi/docs.