### PR TITLE
NFS plugin does not support ControllerServiceCapability

### DIFF
--- a/pkg/nfs/driver.go
+++ b/pkg/nfs/driver.go
@@ -51,6 +51,10 @@ func NewDriver(nodeID, endpoint string) *driver {
 
 	csiDriver := csicommon.NewCSIDriver(driverName, version, nodeID)
 	csiDriver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER})
+	// NFS plugin does not support ControllerServiceCapability now.
+	// If support is added, it should set to appropriate
+	// ControllerServiceCapability RPC types.
+        csiDriver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{csi.ControllerServiceCapability_RPC_UNKNOWN})
 
 	d.csiDriver = csiDriver
 
@@ -67,7 +71,8 @@ func (d *driver) Run() {
 	s := csicommon.NewNonBlockingGRPCServer()
 	s.Start(d.endpoint,
 		csicommon.NewDefaultIdentityServer(d.csiDriver),
-		csicommon.NewDefaultControllerServer(d.csiDriver),
+		// NFS plugin has not implemented ControllerServer.
+		nil,
 		NewNodeServer(d))
 	s.Wait()
 }


### PR DESCRIPTION
Since NFS plugin does not support ControllerServiceCapability,
set it to csi.ControllerServiceCapability_RPC_UNKNOWN.
Also set ControllerServer to nil instead of using the default
because ControllerServer is not implemented in NFS plugin.
If this support is added in the future, capabilities need to
be added accordingly.