### PR TITLE
fix nfs driver.go formatting

### DIFF
--- a/pkg/nfs/driver.go
+++ b/pkg/nfs/driver.go
@@ -54,7 +54,7 @@ func NewDriver(nodeID, endpoint string) *driver {
 	// NFS plugin does not support ControllerServiceCapability now.
 	// If support is added, it should set to appropriate
 	// ControllerServiceCapability RPC types.
-        csiDriver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{csi.ControllerServiceCapability_RPC_UNKNOWN})
+	csiDriver.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{csi.ControllerServiceCapability_RPC_UNKNOWN})
 
 	d.csiDriver = csiDriver
 


### PR DESCRIPTION
latest commit of nfs driver.go had some formatting issues which was causing Travis check failure.  