### PR TITLE
Changing default identity server

### DIFF
--- a/pkg/csi-common/identityserver-default.go
+++ b/pkg/csi-common/identityserver-default.go
@@ -56,7 +56,7 @@ func (ids *DefaultIdentityServer) GetPluginCapabilities(ctx context.Context, req
 			{
 				Type: &csi.PluginCapability_Service_{
 					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_UNKNOWN,
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 					},
 				},
 			},


### PR DESCRIPTION
Change default identity server to advertise csi.PluginCapability_Service_CONTROLLER_SERVICE by default. drivers which are not implementing Controller Service should use a non default identity Server.

Closes: #68 