### PR TITLE
Cleanup after moving livenessprobe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,10 @@ flexadapter:
 nfs:
 	if [ ! -d ./vendor ]; then dep ensure; fi
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o _output/nfsplugin ./app/nfsplugin
-livenessprobe:
-	if [ ! -d ./vendor ]; then dep ensure; fi
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o _output/livenessprobe ./app/livenessprobe/cmd
 hostpath:
 	if [ ! -d ./vendor ]; then dep ensure; fi
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o _output/hostpathplugin ./app/hostpathplugin
-hostpath-container: hostpath livenessprobe
+hostpath-container: hostpath
 	docker build -t $(REGISTRY_NAME)/hostpathplugin:$(IMAGE_VERSION) -f ./pkg/hostpath/extras/docker/Dockerfile .
 iscsi:
 	if [ ! -d ./vendor ]; then dep ensure; fi

--- a/pkg/hostpath/extras/docker/Dockerfile
+++ b/pkg/hostpath/extras/docker/Dockerfile
@@ -3,5 +3,4 @@ LABEL maintainers="Kubernetes Authors"
 LABEL description="HostPath CSI Plugin"
 
 COPY ./_output/hostpathplugin /hostpathplugin
-COPY ./_output/livenessprobe /livenessprobe
 ENTRYPOINT ["/hostpathplugin"]


### PR DESCRIPTION
After moving liveness probe to a separate repo, some references to it in drivers  still existed. This PR cleans them up.