### PR TITLE
hostpath: test with csi-test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -55,16 +55,9 @@
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
-  name = "github.com/golang/mock"
-  packages = ["gomock"]
-  revision = "13f360950a79f5864a972c786a10a50e44b69541"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
-    "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -151,7 +144,7 @@
   branch = "master"
   name = "github.com/kubernetes-csi/csi-test"
   packages = [
-    "driver",
+    "pkg/sanity",
     "utils"
   ]
   revision = "54c9bdefdd6cfdac7dda8a1c6ff44d923da21c64"
@@ -173,6 +166,50 @@
   packages = ["."]
   revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
   version = "1.0.0"
+
+[[projects]]
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types"
+  ]
+  revision = "fa5fabab2a1bfbd924faf4c067d07ae414e2aedf"
+  version = "v1.5.0"
+
+[[projects]]
+  name = "github.com/onsi/gomega"
+  packages = [
+    ".",
+    "format",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types"
+  ]
+  revision = "62bff4df71bdbc266561a0caee19f0594b17c240"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -259,7 +296,8 @@
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock"
+    "mock",
+    "require"
   ]
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
@@ -278,6 +316,9 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "html",
+    "html/atom",
+    "html/charset",
     "http2",
     "http2/hpack",
     "idna",
@@ -298,12 +339,24 @@
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -339,8 +392,6 @@
     "metadata",
     "naming",
     "peer",
-    "reflection",
-    "reflection/grpc_reflection_v1alpha",
     "resolver",
     "resolver/dns",
     "resolver/passthrough",
@@ -676,6 +727,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4663dd72fe1b35e7a7282b6d34d64a41b027bda486289861b1dcb4f1102bb2e5"
+  inputs-digest = "fc3d22a8be08ae6e0776d8426c2834c6bac3c514306119ee6b327a626c14480b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostpath
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostpathDriver(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "hostpath")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	driver := GetHostPathDriver()
+	endpoint := "unix://" + tmp + "/hostpath-driver.sock"
+	s, err := driver.Start("hostpath-driver", "test-node", endpoint)
+	defer s.ForceStop()
+
+	// Now call the test suite.
+	config := sanity.Config{
+		TargetPath:  tmp + "/target-path",
+		StagingPath: tmp + "/staging-path",
+		Address:     endpoint,
+	}
+	sanity.Test(t, &config)
+}


### PR DESCRIPTION
The csi-test framework covers various aspects of the CSI
spec. Automatically testing the hostpath driver for compliance is
useful.

Right now these tests have to be run as a privileged user, otherwise
mounting fails. See
https://github.com/kubernetes-csi/csi-test/issues/73.

Because of this issue I am just posting the changes to get feedback on
whether this would be useful.