### PR TITLE
Validate the volume ID when deleting

### DIFF
--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -111,9 +111,15 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		glog.V(3).Infof("invalid delete volume req: %v", req)
 		return nil, err
 	}
+
 	volumeID := req.VolumeId
-	glog.V(4).Infof("deleting volume %s", volumeID)
 	path := provisionRoot + volumeID
+	// Check if the path specified by volumeID is exist
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		glog.V(3).Infof("invalid volume ID: %s", volumeID)
+		return nil, status.Error(codes.InvalidArgument, "Volume ID doesn't exist")
+	}
+	glog.V(4).Infof("deleting volume %s", volumeID)
 	os.RemoveAll(path)
 	delete(hostPathVolumes, volumeID)
 	return &csi.DeleteVolumeResponse{}, nil


### PR DESCRIPTION
Current code doesn't check if the volume ID from the request exist
or not, so it always try to delete the volume even that volume doesn't
exist. This PR adds volumeID validation code and return error response
if that volume is not there.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>