### PR TITLE
Update to CSI 0.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/container-storage-interface/spec"
   packages = ["lib/go/csi/v0"]
-  revision = "35d9f9d77954980e449e52c3f3e43c21bd8171f5"
-  version = "v0.2.0-rc1"
+  revision = "2178fdeea87f1150a17a63252eee28d4d8141f72"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -55,23 +55,17 @@
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
-  name = "github.com/golang/mock"
-  packages = ["gomock"]
-  revision = "13f360950a79f5864a972c786a10a50e44b69541"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
-    "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
+    "ptypes/wrappers"
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -146,15 +140,6 @@
   packages = ["."]
   revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
   version = "1.0.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/kubernetes-csi/csi-test"
-  packages = [
-    "driver",
-    "utils"
-  ]
-  revision = "54c9bdefdd6cfdac7dda8a1c6ff44d923da21c64"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -339,8 +324,6 @@
     "metadata",
     "naming",
     "peer",
-    "reflection",
-    "reflection/grpc_reflection_v1alpha",
     "resolver",
     "resolver/dns",
     "resolver/passthrough",
@@ -676,6 +659,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4663dd72fe1b35e7a7282b6d34d64a41b027bda486289861b1dcb4f1102bb2e5"
+  inputs-digest = "8b43ab8306203b049af581d7567bd62d58b438ad31ada07c05ab0398c721a0fd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/container-storage-interface/spec"
-  version = "~0.2.0"
+  version = "~0.3.0"
 
 [[constraint]]
   branch = "master"
@@ -72,3 +72,7 @@
 [[override]]
   version = "kubernetes-1.10.0-beta.1"
   name = "k8s.io/api"
+
+[[override]]
+  name = "github.com/golang/protobuf"
+  version = "v1.1.0"

--- a/pkg/cinder/deploy/kubernetes/csi-attacher-cinderplugin.yaml
+++ b/pkg/cinder/deploy/kubernetes/csi-attacher-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/cinder/deploy/kubernetes/csi-nodeplugin-cinderplugin.yaml
+++ b/pkg/cinder/deploy/kubernetes/csi-nodeplugin-cinderplugin.yaml
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/cinder/deploy/kubernetes/csi-provisioner-cinderplugin.yaml
+++ b/pkg/cinder/deploy/kubernetes/csi-provisioner-cinderplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          image: quay.io/k8scsi/csi-provisioner:v0.3.0
           args:
             - "--provisioner=csi-cinderplugin"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/cinder/driver.go
+++ b/pkg/cinder/driver.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	version = "0.2.0"
+	version = "0.3.0"
 )
 
 func NewDriver(nodeID, endpoint string, cloudconfig string) *driver {

--- a/pkg/cinder/nodeserver.go
+++ b/pkg/cinder/nodeserver.go
@@ -33,16 +33,8 @@ type nodeServer struct {
 
 func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
 
-	// Get Mount Provider
-	m, err := mount.GetMountProvider()
+	nodeID, err := getNodeID()
 	if err != nil {
-		glog.V(3).Infof("Failed to GetMountProvider: %v", err)
-		return nil, err
-	}
-
-	nodeID, err := m.GetInstanceID()
-	if err != nil {
-		glog.V(3).Infof("Failed to GetInstanceID: %v", err)
 		return nil, err
 	}
 
@@ -54,6 +46,41 @@ func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) 
 
 	// Using default function
 	return ns.DefaultNodeServer.NodeGetId(ctx, req)
+}
+
+func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+
+	nodeID, err := getNodeID()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodeID) > 0 {
+		return &csi.NodeGetInfoResponse{
+			NodeId: nodeID,
+		}, nil
+	}
+
+	// Using default function
+	return ns.DefaultNodeServer.NodeGetInfo(ctx, req)
+}
+
+func getNodeID() (string, error) {
+
+	// Get Mount Provider
+	m, err := mount.GetMountProvider()
+	if err != nil {
+		glog.V(3).Infof("Failed to GetMountProvider: %v", err)
+		return "", err
+	}
+
+	nodeID, err := m.GetInstanceID()
+	if err != nil {
+		glog.V(3).Infof("Failed to GetInstanceID: %v", err)
+		return "", err
+	}
+
+	return nodeID, nil
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {

--- a/pkg/cinder/nodeserver_test.go
+++ b/pkg/cinder/nodeserver_test.go
@@ -65,6 +65,36 @@ func TestNodeGetId(t *testing.T) {
 	assert.Equal(expectedRes, actualRes)
 }
 
+// Test NodeGetInfo
+func TestNodeGetInfo(t *testing.T) {
+
+	// mock MountMock
+	mmock := new(mount.MountMock)
+	// GetInstanceID() (string, error)
+	mmock.On("GetInstanceID").Return(fakeNodeID, nil)
+	mount.MInstance = mmock
+
+	// Init assert
+	assert := assert.New(t)
+
+	// Expected Result
+	expectedRes := &csi.NodeGetInfoResponse{
+		NodeId: fakeNodeID,
+	}
+
+	// Fake request
+	fakeReq := &csi.NodeGetInfoRequest{}
+
+	// Invoke NodeGetId
+	actualRes, err := fakeNs.NodeGetInfo(fakeCtx, fakeReq)
+	if err != nil {
+		t.Errorf("failed to NodeGetInfo: %v", err)
+	}
+
+	// Assert
+	assert.Equal(expectedRes, actualRes)
+}
+
 // Test NodePublishVolume
 func TestNodePublishVolume(t *testing.T) {
 

--- a/pkg/csi-common/controllerserver-default.go
+++ b/pkg/csi-common/controllerserver-default.go
@@ -85,3 +85,15 @@ func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context
 		Capabilities: cs.Driver.cap,
 	}, nil
 }
+
+func (cs *DefaultControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *DefaultControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (cs *DefaultControllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}

--- a/pkg/csi-common/driver_test.go
+++ b/pkg/csi-common/driver_test.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	vendorVersion = "0.2.0"
+	vendorVersion = "0.3.0"
 )
 
 func NewFakeDriver() *CSIDriver {

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -44,6 +44,14 @@ func (ns *DefaultNodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRe
 	}, nil
 }
 
+func (ns *DefaultNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	glog.V(5).Infof("Using default NodeGetInfo")
+
+	return &csi.NodeGetInfoResponse{
+		NodeId: ns.Driver.nodeID,
+	}, nil
+}
+
 func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	glog.V(5).Infof("Using default NodeGetCapabilities")
 

--- a/pkg/csi-common/nodeserver-default_test.go
+++ b/pkg/csi-common/nodeserver-default_test.go
@@ -38,6 +38,18 @@ func TestNodeGetId(t *testing.T) {
 	assert.Equal(t, resp.GetNodeId(), fakeNodeID)
 }
 
+func TestNodeGetInfo(t *testing.T) {
+	d := NewFakeDriver()
+
+	ns := NewDefaultNodeServer(d)
+
+	// Test valid request
+	req := csi.NodeGetInfoRequest{}
+	resp, err := ns.NodeGetInfo(context.Background(), &req)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.GetNodeId(), fakeNodeID)
+}
+
 func TestNodeGetCapabilities(t *testing.T) {
 	d := NewFakeDriver()
 

--- a/pkg/flexadapter/examples/simplenfs-flexdriver/deploy/kubernetes/csi-attacher-simplenfs-flexdriver.yaml
+++ b/pkg/flexadapter/examples/simplenfs-flexdriver/deploy/kubernetes/csi-attacher-simplenfs-flexdriver.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: docker.io/k8scsi/csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/flexadapter/examples/simplenfs-flexdriver/deploy/kubernetes/csi-nodeplugin-simplenfs-flexdriver.yaml
+++ b/pkg/flexadapter/examples/simplenfs-flexdriver/deploy/kubernetes/csi-nodeplugin-simplenfs-flexdriver.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: docker.io/k8scsi/driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/pkg/flexadapter/flexadapter.go
+++ b/pkg/flexadapter/flexadapter.go
@@ -38,7 +38,7 @@ type flexAdapter struct {
 }
 
 var (
-	version = "0.2.0"
+	version = "0.3.0"
 )
 
 func New() *flexAdapter {

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -128,6 +128,9 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	if req.GetVolumeCapabilities() == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capabilities missing in request")
 	}
+	if _, ok := hostPathVolumes[req.GetVolumeId()]; !ok {
+		return nil, status.Error(codes.NotFound, "Volume does not exist")
+	}
 
 	for _, cap := range req.VolumeCapabilities {
 		if cap.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -56,7 +56,7 @@ var hostPathVolumes map[string]hostPathVolume
 
 var (
 	hostPathDriver *hostPath
-	vendorVersion  = "0.2.0"
+	vendorVersion  = "0.3.0"
 )
 
 func init() {

--- a/pkg/iscsi/driver.go
+++ b/pkg/iscsi/driver.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	version = "0.2.0"
+	version = "0.3.0"
 )
 
 func NewDriver(nodeID, endpoint string) *driver {

--- a/pkg/nfs/deploy/kubernetes/csi-attacher-nfsplugin.yaml
+++ b/pkg/nfs/deploy/kubernetes/csi-attacher-nfsplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -43,7 +43,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: nfs
-          image: quay.io/k8scsi/nfsplugin:v0.2.0
+          image: quay.io/k8scsi/nfsplugin:v0.3.0
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/pkg/nfs/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
+++ b/pkg/nfs/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -37,7 +37,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/nfsplugin:v0.2.0
+          image: quay.io/k8scsi/nfsplugin:v0.3.0
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/pkg/nfs/driver.go
+++ b/pkg/nfs/driver.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	version = "0.2.0"
+	version = "0.3.0"
 )
 
 func NewDriver(nodeID, endpoint string) *driver {


### PR DESCRIPTION
* Add NodeGetInfo
* Add snapshot

As far as I can tell none of the drivers here needs non-default topology in NodeGetInfo or non-true ProbeResponse so nothing is changed wrt those things