### PR TITLE
Output listening address by correct format

### DIFF
--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -105,7 +105,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		csi.RegisterNodeServer(server, ns)
 	}
 
-	glog.Infof("Listening for connections on address: %#v", listener.Addr())
+	glog.Infof("Listening for connections on address: %s %s", proto, listener.Addr())
 
 	server.Serve(listener)
 


### PR DESCRIPTION
When listening tcp address, the IP is displayed by hexadecimal, which
is not friendly for human. This patch outputs correct foramt by
outputing String format.

BEFORE:
```
I0727 13:21:08.438179     420 server.go:108] Listening for connections on address: &net.TCPAddr{IP:net.IP{0x7f, 0x0, 0x0, 0x1}, Port:10000, Zone:""}
```

AFTER:

tcp
```
I0727 13:38:44.937448   19902 server.go:108] Listening for connections on address: tcp 127.0.0.1:10000
```