### PR TITLE
hostpath: Implement ValidateVolumeCapabilities

### DIFF
--- a/hack/e2e-hostpath.sh
+++ b/hack/e2e-hostpath.sh
@@ -13,9 +13,6 @@ CSI_MOUNTPOINT="/mnt"
 APP=hostpathplugin
 
 SKIP="WithCapacity"
-if [ x${TRAVIS} = x"true" ] ; then
-	SKIP="ValidateVolumeCapabilities"
-fi
 
 # Get csi-sanity
 ./hack/get-sanity.sh

--- a/pkg/hostpath/controllerserver.go
+++ b/pkg/hostpath/controllerserver.go
@@ -159,7 +159,35 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 }
 
 func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	return cs.DefaultControllerServer.ValidateVolumeCapabilities(ctx, req)
+
+	// Check arguments
+	if len(req.GetVolumeId()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
+	}
+	if len(req.VolumeCapabilities) == 0 {
+		return nil, status.Error(codes.InvalidArgument, req.VolumeId)
+	}
+
+	if _, err := getVolumeByID(req.GetVolumeId()); err != nil {
+		return nil, status.Error(codes.NotFound, req.GetVolumeId())
+	}
+
+	for _, cap := range req.GetVolumeCapabilities() {
+		if cap.GetMount() == nil && cap.GetBlock() == nil {
+			return nil, status.Error(codes.InvalidArgument, "cannot have both mount and block access type be undefined")
+		}
+
+		// A real driver would check the capabilities of the given volume with
+		// the set of requested capabilities.
+	}
+
+	return &csi.ValidateVolumeCapabilitiesResponse{
+		Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
+			VolumeContext:      req.GetVolumeContext(),
+			VolumeCapabilities: req.GetVolumeCapabilities(),
+			Parameters:         req.GetParameters(),
+		},
+	}, nil
 }
 
 // CreateSnapshot uses tar command to create snapshot for hostpath volume. The tar command can quickly create


### PR DESCRIPTION
This implements a basic version of ValidateVolumeCapabilities for
hostpath driver and removes this from the skip tests list in the e2e
tests.

Running the e2e tests locally always failed because it was skipped for travisCI environment only.