### PR TITLE
hostpath: Add block volume support

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -47,10 +47,12 @@ type hostPath struct {
 }
 
 type hostPathVolume struct {
-	VolName string `json:"volName"`
-	VolID   string `json:"volID"`
-	VolSize int64  `json:"volSize"`
-	VolPath string `json:"volPath"`
+	VolName       string     `json:"volName"`
+	VolID         string     `json:"volID"`
+	VolSize       int64      `json:"volSize"`
+	VolPath       string     `json:"volPath"`
+	VolAccessType accessType `json:"volAccessType"`
+	VolLoopDevice string     `json:"volLoopDevice"`
 }
 
 type hostPathSnapshot struct {


### PR DESCRIPTION
This change adds block volume support to hostpath driver.

When a block volume request is received, a block file is created at
provisionRoot with the requested capacity as size.

At node publish, a loop device is created associated with the block
file. This loop device is then symlinked to the publish target path.
For read only volume publish, the loop device is created with read only
flag.

At node unpublish, the symlinked file is deleted, and the loop device is
detached from the block file.

At volume delete, the block file is deleted.