### PR TITLE
Update sidecar containers for NFS Driver and Fix ControllerGetCapability error

### DIFF
--- a/pkg/nfs/deploy/kubernetes/csi-attacher-nfsplugin.yaml
+++ b/pkg/nfs/deploy/kubernetes/csi-attacher-nfsplugin.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccount: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v0.3.0
+          image: quay.io/k8scsi/csi-attacher:v1.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -43,7 +43,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: nfs
-          image: quay.io/k8scsi/nfsplugin:v0.3.0
+          image: quay.io/k8scsi/nfsplugin:v1.0
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/pkg/nfs/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
+++ b/pkg/nfs/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
@@ -17,10 +17,11 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: quay.io/k8scsi/driver-registrar:v0.3.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/csi-nfsplugin/csi.sock"
           env:
             - name: ADDRESS
               value: /plugin/csi.sock
@@ -31,13 +32,15 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
         - name: nfs
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/nfsplugin:v0.3.0
+          image: quay.io/k8scsi/nfsplugin:v1.0
           args :
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -63,4 +66,8 @@ spec:
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
             type: Directory

--- a/pkg/nfs/driver.go
+++ b/pkg/nfs/driver.go
@@ -72,7 +72,7 @@ func (d *driver) Run() {
 	s.Start(d.endpoint,
 		csicommon.NewDefaultIdentityServer(d.csiDriver),
 		// NFS plugin has not implemented ControllerServer.
-		nil,
+		csicommon.NewDefaultControllerServer(d.csiDriver),
 		NewNodeServer(d))
 	s.Wait()
 }


### PR DESCRIPTION
Currently simply deploying the NFS driver based on the YAML files doesn't work. 

This PR: 
 * updates CSI attacher and driver registrar YAML files for the NFS Driver
 * Fixes this controller server error by making driver utilize the default controller server in CSICommon package: 
```I0205 15:34:08.633172       1 connection.go:242] GRPC call: /csi.v1.Identity/GetPluginCapabilities
I0205 15:34:08.633187       1 connection.go:243] GRPC request: {}
I0205 15:34:08.634317       1 connection.go:245] GRPC response: {"capabilities":[{"Type":{"Service":{"type":1}}}]}
I0205 15:34:08.636355       1 connection.go:246] GRPC error: <nil>
I0205 15:34:08.636383       1 connection.go:242] GRPC call: /csi.v1.Controller/ControllerGetCapabilities
I0205 15:34:08.636405       1 connection.go:243] GRPC request: {}
I0205 15:34:08.639697       1 connection.go:245] GRPC response: {}
I0205 15:34:08.641398       1 connection.go:246] GRPC error: rpc error: code = Unimplemented desc = unknown service csi.v1.Controller
E0205 15:34:08.643479       1 main.go:142] rpc error: code = Unimplemented desc = unknown service csi.v1.Controller
```