### PR TITLE
Revert csi to v0.3.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/container-storage-interface/spec"
-  version = "1.0.0"
+  version = "0.3.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
kubernetes 1.12.x only supports v0.3.0
current versions in Gopkg.toml causes version conflict when
importing this project